### PR TITLE
BUGFIX: Packagist failed to update because of a typo in the composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "neos/neos": "^3.0 || ^4.0 || ^5.0 || ^7.0 || ^8.0",
-        "punktDe/sentry-flow": "^4.0"
+        "punktde/sentry-flow": "^4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
See https://packagist.org/packages/punktDe/sentry-neos => Click on "Update now"

![Screenshot 2022-04-08 at 16 33 54](https://user-images.githubusercontent.com/5636715/162459571-b57a0d3f-5038-4967-96ef-3e9327abf4bb.png)

