### PR TITLE
 TASK: Mark as Neos 9 compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "name": "punktde/sentry-neos",
     "license": "MIT",
     "require": {
-        "neos/neos": "^3.0 || ^4.0 || ^5.0 || ^7.0 || ^8.0",
+        "neos/neos": "^3.0 || ^4.0 || ^5.0 || ^7.0 || ^8.0 || ^9.0",
         "punktde/sentry-flow": "^4.0"
     },
     "autoload": {


### PR DESCRIPTION
As suspected we can already declare this package compatible with Neos 9. 